### PR TITLE
fixes encoding issues

### DIFF
--- a/R/readtextgrid.R
+++ b/R/readtextgrid.R
@@ -12,13 +12,18 @@
 #' @examples
 #' tg <- system.file("Mary_John_bell.TextGrid", package = "readtextgrid")
 #' read_textgrid(tg)
-read_textgrid <- function(path, file = NULL) {
+read_textgrid <- function(path, file = NULL, encoding = NULL) {
   if (is.null(file)) {
     file <- basename(path)
   }
 
+  if (is.null(encoding)) {
+    encoding <- readr::guess_encoding(file)$encoding[1]
+    file_locale <- readr::locale(encoding=encoding)
+  }
+
   path |>
-    readr::read_lines() |>
+    readr::read_lines(locale=file_locale) |>
     read_textgrid_lines(file = file)
 }
 

--- a/R/readtextgrid.R
+++ b/R/readtextgrid.R
@@ -18,7 +18,7 @@ read_textgrid <- function(path, file = NULL, encoding = NULL) {
   }
 
   if (is.null(encoding)) {
-    encoding <- readr::guess_encoding(file)$encoding[1]
+    encoding <- readr::guess_encoding(path)$encoding[1]
     file_locale <- readr::locale(encoding=encoding)
   }
 


### PR DESCRIPTION
`read_textgrid()` accepts an encoding override; otherwise, encoding of TextGrid is guessed.

Should close https://github.com/tjmahr/readtextgrid/issues/7 .