### PR TITLE
Ensure compatibility with TextGrids exported from Elan

### DIFF
--- a/R/readtextgrid.R
+++ b/R/readtextgrid.R
@@ -80,7 +80,7 @@ parse_textgrid_lines <- function(lines) {
 }
 
 slice_sections <- function(lines, section_head) {
-  re <- sprintf("^\\s+%s \\[\\d+\\]:", section_head)
+  re <- sprintf("^\\s+%s ?\\[\\d+\\]:?", section_head)
   starts <- stringr::str_which(lines, re)
   ends <- c(starts[-1] - 1, length(lines))
   purrr::map2(starts, ends, function(x, y) lines[seq(x, y, by = 1)])


### PR DESCRIPTION
A TextGrid exported by Elan 6.7 lacks a space in (e.g.) `item[1]` and a colon in (e.g.) `intervals [1]`. This is a valid Praat-readable TextGrid.

Ultimately, this is a band-aid toward #4, but at least it fixes a bug for a non-obscure use case.